### PR TITLE
Add option to package config in lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 # Ignore all bundled JS files
 files/deployable/dist/*.js
 files/deployable/dist/*.js.map
+
+# ignore generated config file
+files/deployable/dist/config.json
+
+# ignore node-modules
+files/deployable/node_modules

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ enforce Cognito Authentication through a configured Cognito User Pool.
 - Existing Cognito User Pool and User Pool Client.
 
 ## Usage
-To use this module, source it into one your Terraform project like so:
+To use this module, source it into your Terraform project like so:
 
 ```
 data "aws_cognito_user_pools" "user_pool" {
@@ -53,8 +53,32 @@ resource "aws_cloudfront_distribution" "my_cloudfront_distribution" {
 }
 
 ```
+### Lambda Configuration Mode
+
+The module supports three different strategies to make the required cognito-at-edge config available to the lambda function, controlled by the `lambda_config_mode` variable.
+
+> [!NOTE] 
+> While the default config mode is `dynamic` (for backwards compatibility), either of the other modes is a better choice for most users.
+
+#### `dynamic`
+
+In this mode, the lambda introspects the IAM role/policy to determine the SSM Parameter that contains the config.  This is the current/default behaviour if not supplied by the calling module.
+
+This requires at least three round trips to AWS, which can cause 503 responses from Cloudfront during lambda cold starts when the round trips and cognito-at-edge initialisation collectively takes longer than the maximum lambda-at-edge run time (5 seconds). The lambda code does not need to be redeployed when config changes are made (so terraform applies are fast).
+
+#### `hybrid`
+
+In this mode, the name of the parameter store entry that contains the config is written into a config file shipped with the lambda. Versus 'dynamic' mode this removes the need for IAM introspection, which saves two round trips to AWS, which reduces the likelihood that cold starts exceed the max run time. The net result is that this mode will produce signicantly less 503's, particularly if your cloudfront distribution is used in regions a long distance from us-east-1, or only used sporadically. Changes to the config of the lambda will still be fast, but changing the actual SSM entry that holds the config will force a lambda redeploy (which takes minutes). This mode will be cheaper to run than 'dynamic' (as on average cold starts consume 1-2 seconds less lambda runtime).
+
+#### `static`
+
+In this mode, the entire cognito-at-edge config is written into a config file shipped with the lambda.  Versus 'hybrid' mode, this saves another round trip to AWS (the fetching of the config from SSM), which yields even faster cold start times and will therefore be cheaper still to run.  The downsides:
+* any config change requires a reprovisioning of the lambda (slow)
+* secrets passed into the module config will be written to the config file in the local file system, which may lead to secret leakage.   
+To prevent this happening unintentionally, if the calling module sets `cognito_user_pool_app_client_secret` and `lambda_config_mode = static`, then plan/apply will fail unless `lambda_config_allow_insecure_secret_storage = true` is also set.
+
 ### Cloudwatch logging
-If a Lambda@Edge function has IAM permission to `logs:CreateLogGroup` then it will create a Cloudwatch log group called `/aws/lambda/us-east-1.<lambda-name>` in every CloudFront region that serves a request, which can result in logging proliferating across many regions, as described in https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-logs.html#lambda-at-edge-logs .  This auto-created log group has no retention policy set, so in addition to Cloudwatch ingest costs, Cloudwatch storage costs increase over time for the life of the function.  Setting `cloudwatch_enable_log_group_create = false` will mean that the IAM policies in the module will not grant `logs:CreateLogGroup` to the edge-auth Lambda@Edge function, and if the log group does not exit, no logging happens (so no Cloudwatch ingest or storage costs).  Notes:
+If a Lambda@Edge function has IAM permission to `logs:CreateLogGroup` then it will create a Cloudwatch log group called `/aws/lambda/us-east-1.<lambda-name>` in every CloudFront region that serves a request, which can result in logging proliferating across many regions, as described in https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/edge-functions-logs.html#lambda-at-edge-logs .  This auto-created log group has no retention policy set, so in addition to Cloudwatch ingest costs, Cloudwatch storage costs increase over time for the life of the function.  Setting `cloudwatch_enable_log_group_create = false` will mean that the IAM policies in the module will not grant `logs:CreateLogGroup` to the edge-auth Lambda@Edge function, and if the log group does not exit, no logging happens (avoiding Cloudwatch ingest and storage costs).  Note:
 - If the variable is `false` and logging is required in a specific region, the caller is responsible for ensuring the log group exists in that region.
 - Retroactively setting the variable to `false` is not sufficient to disable logging if the log group already exists in a region - manual deletion of the unwanted log groups will be required to prevent further logging.
 - If a policy outside the module grants the edge-auth function rights to `logs:CreateLogGroup`, then Lambda@Edge will still create the log group and log.
@@ -79,6 +103,7 @@ In order to properly delete this resource, it should be manually cleaned up, [in
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
@@ -97,6 +122,7 @@ No modules.
 | [aws_kms_key.ssm_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_lambda_function.cloudfront_auth_edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_ssm_parameter.lambda_configuration_parameters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [local_file.lambda_configuration](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.install_lambda_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [archive_file.lambda_edge_bundle](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
@@ -105,7 +131,6 @@ No modules.
 | [aws_iam_policy_document.allow_lambda_service_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.allow_ssm_parameter_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.allow_ssm_parameter_permission_for_lambda_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
 
@@ -123,6 +148,8 @@ No modules.
 | <a name="input_cognito_user_pool_id"></a> [cognito\_user\_pool\_id](#input\_cognito\_user\_pool\_id) | Cognito User Pool ID for the targeted user pool. | `string` | n/a | yes |
 | <a name="input_cognito_user_pool_name"></a> [cognito\_user\_pool\_name](#input\_cognito\_user\_pool\_name) | Name of the Cognito User Pool to utilize. Required if 'cognito\_user\_pool\_domain' is not set. | `string` | `""` | no |
 | <a name="input_cognito_user_pool_region"></a> [cognito\_user\_pool\_region](#input\_cognito\_user\_pool\_region) | AWS region where the cognito user pool was created. | `string` | `"us-west-2"` | no |
+| <a name="input_lambda_config_allow_insecure_secret_storage"></a> [lambda\_config\_allow\_insecure\_secret\_storage](#input\_lambda\_config\_allow\_insecure\_secret\_storage) | Allow secrets to be stored in the lambda config file, defaults to false. | `bool` | `false` | no |
+| <a name="input_lambda_config_mode"></a> [lambda\_config\_mode](#input\_lambda\_config\_mode) | Which strategy to use to supply config to the lambda function, defaults to 'dynamic'. | `string` | `"dynamic"` | no |
 | <a name="input_lambda_runtime"></a> [lambda\_runtime](#input\_lambda\_runtime) | Lambda runtime to utilize for Lambda@Edge. | `string` | `"nodejs20.x"` | no |
 | <a name="input_lambda_timeout"></a> [lambda\_timeout](#input\_lambda\_timeout) | Amount of timeout in seconds to set on for Lambda@Edge. | `number` | `5` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to prefix on all infrastructure created by this module. | `string` | n/a | yes |
@@ -133,6 +160,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN for the Lambda@Edge created by this module. |
-| <a name="output_name"></a> [name](#output\_name) | Name of the Lambda@Edge created by this module. |
+| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the Lambda@Edge created by this module. |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | Qualified ARN for the Lambda@Edge created by this module. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/iam.tf
+++ b/iam.tf
@@ -1,5 +1,4 @@
 data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
 
 data "aws_iam_policy_document" "allow_lambda_service_assume" {
   statement {
@@ -66,29 +65,37 @@ data "aws_iam_policy_document" "allow_lambda_edge_self_role_read" {
 }
 
 resource "aws_iam_role_policy" "ssm_parameter_permission_for_lambda_auth" {
-  name = "SSM_PARAMETER_PERMISSION_FOR_LAMBDA_AUTH"
-  role = aws_iam_role.lambda_at_edge.id
+  count = local.create_ssm_parameter ? 1 : 0
+  name  = "SSM_PARAMETER_PERMISSION_FOR_LAMBDA_AUTH"
+  role  = aws_iam_role.lambda_at_edge.id
 
   policy = data.aws_iam_policy_document.allow_ssm_parameter_permission_for_lambda_auth.json
 }
 
 data "aws_iam_policy_document" "allow_ssm_parameter_permission_for_lambda_auth" {
-  statement {
-    actions   = ["ssm:GetParameter"]
-    resources = [aws_ssm_parameter.lambda_configuration_parameters.arn]
+  dynamic "statement" {
+    for_each = local.create_ssm_parameter ? [1] : []
+    content {
+      actions   = ["ssm:GetParameter"]
+      resources = [aws_ssm_parameter.lambda_configuration_parameters[0].arn]
+    }
   }
 }
 
 resource "aws_iam_role_policy" "ssm_parameter_decrypt" {
-  name = "ssmParameterDecrypt"
-  role = aws_iam_role.lambda_at_edge.id
+  count = local.create_ssm_parameter ? 1 : 0
+  name  = "ssmParameterDecrypt"
+  role  = aws_iam_role.lambda_at_edge.id
 
   policy = data.aws_iam_policy_document.allow_ssm_parameter_decrypt.json
 }
 
 data "aws_iam_policy_document" "allow_ssm_parameter_decrypt" {
-  statement {
-    actions   = ["kms:Decrypt"]
-    resources = [aws_kms_key.ssm_kms_key.arn]
+  dynamic "statement" {
+    for_each = local.create_ssm_parameter ? [1] : []
+    content {
+      actions   = ["kms:Decrypt"]
+      resources = [aws_kms_key.ssm_kms_key[0].arn]
+    }
   }
 }

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,6 +1,22 @@
 locals {
-  tracked_files    = setunion(fileset("${path.module}/files/deployable/", "*.{js,json}"), fileset("${path.module}/files/deployable/", "patches/*.patch"))
+  lambda_config_file = "config.json" # if changed, update configFile in files/deployable/index.js as well
+  tracked_files = setunion(
+    fileset("${path.module}/files/deployable/", "*.{js,json}"),
+    fileset("${path.module}/files/deployable/", "dist/${local.lambda_config_file}"),
+    fileset("${path.module}/files/deployable/", "patches/*.patch")
+  )
   tracked_file_sha = sha256(join(",", [for file in local.tracked_files : filesha256("${path.module}/files/deployable/${file}")]))
+
+  # This is an ugly hack to force terraform plan/apply to fail if the supplied config would put secrets
+  # into the lambda config file and the user hasn't set var.lambda_config_allow_insecure_secret_storage.  
+  # An alternative would be to use the extended validation introduced in tf v1.9, but forcing that as the
+  # minimum required version would be a breaking change and also prevent using the module with opentofu
+  assert_static_and_secrets = var.lambda_config_mode == "static" && var.cognito_user_pool_app_client_secret != null && !var.lambda_config_allow_insecure_secret_storage ? file("ERROR: client secrets and lambda_config_mode = static should not be used together!") : null
+
+  # we only create the config file in the lambda bundle if the config mode is 'static' or 'hybrid',
+  # this assumes that the assert above will cause terraform to fail if the user combines config mode 'static'
+  # with secrets, so we don't need to check for that here.
+  include_config_file = var.lambda_config_mode != "dynamic" ? true : false
 }
 
 resource "null_resource" "install_lambda_dependencies" {
@@ -14,8 +30,25 @@ resource "null_resource" "install_lambda_dependencies" {
   }
 }
 
+# the content of the config file for the lambda function, which is shipped along with the lambda
+# code if local.include_config_file above evaluates to true (ie if config_mode != 'dynamic).  
+# If config_mode is 'static' then the content is all of local.lambda_configuration, otherwise
+# config_mode is implicitly 'hybrid' and the content is a single value 'parameterName' which
+# contains the name of the SSM parameter that holds the cognito-at-edge configuration.
+resource "local_file" "lambda_configuration" {
+  count    = local.include_config_file ? 1 : 0
+  filename = "${path.module}/files/deployable/dist/${local.lambda_config_file}"
+
+  content = var.lambda_config_mode == "static" ? local.lambda_configuration : jsonencode({
+    parameterName = aws_ssm_parameter.lambda_configuration_parameters[0].name
+  })
+}
+
 data "archive_file" "lambda_edge_bundle" {
-  depends_on = [null_resource.install_lambda_dependencies]
+  depends_on = [
+    null_resource.install_lambda_dependencies,
+    local_file.lambda_configuration
+  ]
 
   type             = "zip"
   source_dir       = "${path.module}/files/deployable/dist"
@@ -36,5 +69,3 @@ resource "aws_lambda_function" "cloudfront_auth_edge" {
 
   skip_destroy = true
 }
-
-

--- a/output.tf
+++ b/output.tf
@@ -8,7 +8,7 @@ output "arn" {
   value       = aws_lambda_function.cloudfront_auth_edge.arn
 }
 
-output "name" {
+output "function_name" {
   description = "Name of the Lambda@Edge created by this module."
   value       = aws_lambda_function.cloudfront_auth_edge.function_name
 }

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,5 +1,5 @@
 locals {
-  lambda_configuration = merge({
+  lambda_configuration = jsonencode(merge({
     region               = var.cognito_user_pool_region
     userPoolId           = var.cognito_user_pool_id
     userPoolAppId        = var.cognito_user_pool_app_client_id
@@ -9,10 +9,14 @@ locals {
     disableCookieDomain  = var.cognito_disable_cookie_domain
     logLevel             = var.cognito_log_level
     parseAuthPath        = var.cognito_redirect_path
-  }, var.cognito_additional_settings)
+  }, var.cognito_additional_settings))
+
+  # if config_mode is not 'static' (ie 'dynamic' or 'hybrid') then we need to create the SSM parameter
+  create_ssm_parameter = var.lambda_config_mode != "static" ? true : false
 }
 
 resource "aws_kms_key" "ssm_kms_key" {
+  count                   = local.create_ssm_parameter ? 1 : 0
   description             = "KMS Encryption key for ${var.name} lambda-edge auth"
   deletion_window_in_days = 7
   tags                    = var.tags
@@ -20,10 +24,11 @@ resource "aws_kms_key" "ssm_kms_key" {
 }
 
 resource "aws_ssm_parameter" "lambda_configuration_parameters" {
+  count       = local.create_ssm_parameter ? 1 : 0
   name        = "/${var.name}/lambda/edge/configuration"
   description = "Lambda@Edge Configuration for Application[${var.name}]"
   type        = "SecureString"
-  key_id      = aws_kms_key.ssm_kms_key.key_id
-  value       = jsonencode(local.lambda_configuration)
+  key_id      = aws_kms_key.ssm_kms_key[0].key_id
+  value       = local.lambda_configuration
   tags        = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -39,6 +39,22 @@ variable "lambda_timeout" {
   default     = 5
 }
 
+variable "lambda_config_mode" {
+  description = "Which strategy to use to supply config to the lambda function, defaults to 'dynamic'."
+  type        = string
+  default     = "dynamic"
+  validation {
+    condition     = contains(["dynamic", "hybrid", "static"], var.lambda_config_mode)
+    error_message = "Input var.lambda_config_mode must be one of \"dynamic\", \"hybrid\", \"static\"."
+  }
+}
+
+variable "lambda_config_allow_insecure_secret_storage" {
+  description = "Allow secrets to be stored in the lambda config file, defaults to false."
+  type        = bool
+  default     = false
+}
+
 # ================================================================================================================
 # Cognito @ Edge Configurations
 # ================================================================================================================
@@ -111,4 +127,3 @@ variable "cognito_additional_settings" {
   type        = any
   default     = {}
 }
-


### PR DESCRIPTION
from the commit message:

IAM introspection and config fetch from SSM in us-east-1 can be slow, which causes sporadic 503 errors in regions far from us-east-1. This change adds an input lambda_config_mode which causes the json config to be written to a file packaged/deployed with the lambda code - see the comments in the README for further rationale.

default behaviour is to continue to use IAM introspection, so this should be a non-breaking change.
