### PR TITLE
write SSM parameter name to config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@
 # Ignore all bundled JS files
 files/deployable/dist/*.js
 files/deployable/dist/*.js.map
+
+# ignore generated config file
+files/deployable/dist/config.json
+
+# ignore node-modules
+files/deployable/node_modules

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ In order to properly delete this resource, it should be manually cleaned up, [in
 |------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | 2.4.0 |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.26.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.5.2 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
@@ -91,17 +92,16 @@ No modules.
 |------|------|
 | [aws_iam_role.lambda_at_edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.allow_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.lambda_edge_self_role_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ssm_parameter_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.ssm_parameter_permission_for_lambda_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_kms_key.ssm_kms_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_lambda_function.cloudfront_auth_edge](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
 | [aws_ssm_parameter.lambda_configuration_parameters](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [local_file.lambda_configuration](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [null_resource.install_lambda_dependencies](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [archive_file.lambda_edge_bundle](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.allow_cloudwatch_logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.allow_lambda_edge_self_role_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.allow_lambda_service_assume](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.allow_ssm_parameter_decrypt](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.allow_ssm_parameter_permission_for_lambda_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -133,6 +133,6 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN for the Lambda@Edge created by this module. |
-| <a name="output_name"></a> [name](#output\_name) | Name of the Lambda@Edge created by this module. |
+| <a name="output_function_name"></a> [function\_name](#output\_function\_name) | Name of the Lambda@Edge created by this module. |
 | <a name="output_qualified_arn"></a> [qualified\_arn](#output\_qualified\_arn) | Qualified ARN for the Lambda@Edge created by this module. |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/iam.tf
+++ b/iam.tf
@@ -47,24 +47,6 @@ data "aws_iam_policy_document" "allow_cloudwatch_logs" {
   }
 }
 
-resource "aws_iam_role_policy" "lambda_edge_self_role_read" {
-  name = "LambdaEdgeSelfRoleRead"
-  role = aws_iam_role.lambda_at_edge.id
-
-  policy = data.aws_iam_policy_document.allow_lambda_edge_self_role_read.json
-}
-
-data "aws_iam_policy_document" "allow_lambda_edge_self_role_read" {
-  statement {
-    actions   = ["iam:GetRolePolicy"]
-    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.name}-lambda-edge-role"]
-  }
-  statement {
-    actions   = ["sts:GetCallerIdentity"]
-    resources = ["*"]
-  }
-}
-
 resource "aws_iam_role_policy" "ssm_parameter_permission_for_lambda_auth" {
   name = "SSM_PARAMETER_PERMISSION_FOR_LAMBDA_AUTH"
   role = aws_iam_role.lambda_at_edge.id

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,4 +1,6 @@
 locals {
+  lambda_config_file = "config.json" # if changed, update configFile in files/deployable/index.js as well
+
   tracked_files    = setunion(fileset("${path.module}/files/deployable/", "*.{js,json}"), fileset("${path.module}/files/deployable/", "patches/*.patch"))
   tracked_file_sha = sha256(join(",", [for file in local.tracked_files : filesha256("${path.module}/files/deployable/${file}")]))
 }
@@ -14,9 +16,20 @@ resource "null_resource" "install_lambda_dependencies" {
   }
 }
 
-data "archive_file" "lambda_edge_bundle" {
-  depends_on = [null_resource.install_lambda_dependencies]
+# create a config file for the lambda function, which is shipped along with the lambda code - contains
+# a single value, the name of the SSM parameter that contains the lambda-at-edge configuration
+resource "local_file" "lambda_configuration" {
+  filename = "${path.module}/files/deployable/dist/${local.lambda_config_file}"
+  content = jsonencode({
+    parameterName = aws_ssm_parameter.lambda_configuration_parameters.name
+  })
+}
 
+data "archive_file" "lambda_edge_bundle" {
+  depends_on = [
+    null_resource.install_lambda_dependencies,
+    local_file.lambda_configuration
+  ]
   type             = "zip"
   source_dir       = "${path.module}/files/deployable/dist"
   output_path      = "${path.module}/files/${local.tracked_file_sha}.zip"

--- a/output.tf
+++ b/output.tf
@@ -8,7 +8,7 @@ output "arn" {
   value       = aws_lambda_function.cloudfront_auth_edge.arn
 }
 
-output "name" {
+output "function_name" {
   description = "Name of the Lambda@Edge created by this module."
   value       = aws_lambda_function.cloudfront_auth_edge.function_name
 }


### PR DESCRIPTION
the round trips to IAM to fetch the role and policy to determine the name of the SSM parameter that holds the lambda config can drive the coldstart initialisation time for the lambda beyond 5 seconds, which then causes cloudfront to throw a 503 error. This change writes the name of the SSM parameter to a local config file which is deployed with the lambda code.  When invoked by cloudfront the lambda reads the config file to determine the name of the SSM parameter to fetch.  This reduces the number of round trips to IAM, which speeds up cold starts and reduces the 503 error rate.

this change is an alternative approach to [143](https://github.com/disney/terraform-aws-lambda-at-edge-cognito-authentication/pull/143) and also contains the change in [144](https://github.com/disney/terraform-aws-lambda-at-edge-cognito-authentication/pull/144), those PR's can be closed if/when this is merged.

@KenFigueiredo FYI